### PR TITLE
Fix example code in README.md so that it compiles on current edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Then, in `src/main.rs`:
 use treemap::{MapItem, Mappable, Rect, TreemapLayout};
 
 fn main() {
-    let mut layout = TreemapLayout::new();
+    let layout = TreemapLayout::new();
     let bounds = Rect::from_points(0.0, 0.0, 6.0, 4.0);
-    let mut items: Vec<Box<Mappable>> = vec![
+    let mut items: Vec<Box<dyn Mappable>> = vec![
         Box::new(MapItem::with_size(6.0)),
         Box::new(MapItem::with_size(6.0)),
         Box::new(MapItem::with_size(4.0)),


### PR DESCRIPTION
I hope you don't mind this pull request.

I tried running your example in `README.md`, and it didn't compile. There was a small modification I had to make to make the example run (also, there was an unnecessary `mut` in there that I took out). I made those changes to your `README.md`.